### PR TITLE
[RADE-46] Added login endpoint 

### DIFF
--- a/bytepit_api/database/ddl.sql
+++ b/bytepit_api/database/ddl.sql
@@ -7,11 +7,12 @@ CREATE TABLE users (
     role            user_role       NOT NULL,
     username        VARCHAR(32)     NOT NULL CHECK (LENGTH(username) > 3) UNIQUE,
     image           BYTEA,
-    password        TEXT            NOT NULL,
+    password_hash   VARCHAR(255)    NOT NULL,
     email           VARCHAR(128)    NOT NULL CHECK (LENGTH(email) > 4) UNIQUE,
     name            VARCHAR(64)     NOT NULL,
     surname         VARCHAR(64)     NOT NULL,
-    is_verified     BOOLEAN         NOT NULL
+    is_verified     BOOLEAN         NOT NULL,
+    created_on      TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX index_users_email ON users (email);
@@ -26,7 +27,8 @@ CREATE TABLE problems (
     runtime_limit   TIME            NOT NULL,
     description     TEXT            NOT NULL,
     tests_dir       TEXT            NOT NULL,
-    is_private      BOOLEAN         NOT NULL
+    is_private      BOOLEAN         NOT NULL,
+    created_on      TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE competition (

--- a/bytepit_api/database/queries.py
+++ b/bytepit_api/database/queries.py
@@ -1,0 +1,13 @@
+import uuid
+
+from bytepit_api.database import db
+from bytepit_api.models.auth_schemes import UserInDB
+
+
+def get_user_by_username(username: str):
+    query_tuple = ("SELECT * FROM users WHERE username = %s", (username,))
+    result = db.execute_one(query_tuple)
+    if result["result"]:
+        return UserInDB(**result["result"][0])
+    else:
+        return None

--- a/bytepit_api/helpers/login_helpers.py
+++ b/bytepit_api/helpers/login_helpers.py
@@ -1,0 +1,39 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+from typing import Union
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from bytepit_api.database.queries import get_user_by_username
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALGORITHM = "HS256"
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password, password_hash):
+    return pwd_context.verify(plain_password, password_hash)
+
+
+def authenticate_user(username: str, password: str):
+    user = get_user_by_username(username)
+    if not user:
+        return False
+    if not verify_password(password, user.password_hash):
+        return False
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/bytepit_api/models/auth_schemes.py
+++ b/bytepit_api/models/auth_schemes.py
@@ -1,4 +1,5 @@
 import inspect
+import uuid
 
 from enum import Enum
 from typing import Annotated, Union
@@ -52,3 +53,17 @@ class LoginForm(BaseModel):
     client_id: Annotated[Union[str, None], Form()] = None
     client_secret: Annotated[Union[str, None], Form()] = None
     grant_type: Annotated[Union[str, None], Form(pattern="password")] = None
+
+
+class User(BaseModel):
+    username: str
+    email: str
+    role: str
+    name: str
+    surname: str
+    is_verified: bool
+
+
+class UserInDB(User):
+    id: uuid.UUID
+    password_hash: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 fastapi
+fastapi-mail
 pydantic[email]
 uvicorn
 requests
 python-multipart
 psycopg
+python-jose
+passlib[bcrypt]


### PR DESCRIPTION
I also changed up ddl.sql a bit so it makes more sense, plus I added `created_on` column to `users` and `problems` tables. It's always good to have these.

At the moment, because we do not have `/register` endpoint, the only way to login is to manually insert a user row into users table and test it out that way:
1. (if not already done) Open database container in docker and run all the queries from our `ddl.sql` file to create tables, enum, index, extension...
2. Manually import user into database (run query in database docker container):
```
"INSERT INTO users (role, username, password_hash, email, name, surname, is_verified) 
VALUES ('Contestant', 'testcontestant', '$2b$12$KPLHOyQDeGr.vD.tilyUD.W7tHzZgimuNLJvT.V1xD6ulr5gRiMDy', 'test.contestant@example.com', 'TestName', 'TestSurname', true);"
```
3. Go to our swagger (http://localhost:8000/docs#) and test out the /auth/login endpoint by putting `testcontestant` as a username and `1234` as a password.
4. If you got access_token and a token_type as a response, it's working!