### PR TITLE
[RADE-63] Login and required dependencies finished

### DIFF
--- a/bytepit_api/api.py
+++ b/bytepit_api/api.py
@@ -2,11 +2,13 @@ from fastapi import APIRouter, FastAPI
 
 from bytepit_api.routers.admin import router as admin_router
 from bytepit_api.routers.auth import router as auth_router
+from bytepit_api.routers.user import router as user_router
 
 
 router = APIRouter()
 router.include_router(admin_router)
 router.include_router(auth_router)
+router.include_router(user_router)
 
 app = FastAPI()
 app.include_router(router)

--- a/bytepit_api/database/database.py
+++ b/bytepit_api/database/database.py
@@ -25,8 +25,10 @@ class Database:
     def execute_one(self, query_tuple: tuple):
         try:
             assert isinstance(query_tuple[0], str), "Query must be a string"
-            assert query_tuple[1] is None or isinstance(query_tuple[1], tuple), "Query parameters must be a tuple or None"
-            
+            assert query_tuple[1] is None or isinstance(
+                query_tuple[1], tuple
+            ), "Query parameters must be a tuple or None"
+
             (query, param_tuple) = query_tuple
 
             cursor = self.connection.cursor()
@@ -48,8 +50,10 @@ class Database:
             with self.connection.transaction():
                 for query, param_tuple in query_tuple_list:
                     assert isinstance(query, str), "Query must be a string"
-                    assert param_tuple is None or isinstance(param_tuple, tuple), "Query parameters must be a tuple or None"
-                    
+                    assert param_tuple is None or isinstance(
+                        param_tuple, tuple
+                    ), "Query parameters must be a tuple or None"
+
                     cursor.execute(query, param_tuple)
                     total_affected_rows += cursor.rowcount
                 return {"affected_rows": total_affected_rows}

--- a/bytepit_api/database/ddl.sql
+++ b/bytepit_api/database/ddl.sql
@@ -7,11 +7,12 @@ CREATE TABLE users (
     role            user_role       NOT NULL,
     username        VARCHAR(32)     NOT NULL CHECK (LENGTH(username) > 3) UNIQUE,
     image           BYTEA,
-    password        TEXT            NOT NULL,
+    password_hash   VARCHAR(255)    NOT NULL,
     email           VARCHAR(128)    NOT NULL CHECK (LENGTH(email) > 4) UNIQUE,
     name            VARCHAR(64)     NOT NULL,
     surname         VARCHAR(64)     NOT NULL,
-    is_verified     BOOLEAN         NOT NULL
+    is_verified     BOOLEAN         NOT NULL,
+    created_on      TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX index_users_email ON users (email);
@@ -26,7 +27,8 @@ CREATE TABLE problems (
     runtime_limit   TIME            NOT NULL,
     description     TEXT            NOT NULL,
     tests_dir       TEXT            NOT NULL,
-    is_private      BOOLEAN         NOT NULL
+    is_private      BOOLEAN         NOT NULL,
+    created_on      TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE competition (

--- a/bytepit_api/database/queries.py
+++ b/bytepit_api/database/queries.py
@@ -1,11 +1,18 @@
-import uuid
-
 from bytepit_api.database import db
 from bytepit_api.models.auth_schemes import UserInDB
 
 
 def get_user_by_username(username: str):
     query_tuple = ("SELECT * FROM users WHERE username = %s", (username,))
+    result = db.execute_one(query_tuple)
+    if result["result"]:
+        return UserInDB(**result["result"][0])
+    else:
+        return None
+
+
+def get_user_by_email(email: str):
+    query_tuple = ("SELECT * FROM users WHERE email = %s", (email,))
     result = db.execute_one(query_tuple)
     if result["result"]:
         return UserInDB(**result["result"][0])

--- a/bytepit_api/database/queries.py
+++ b/bytepit_api/database/queries.py
@@ -1,0 +1,13 @@
+import uuid
+
+from bytepit_api.database import db
+from bytepit_api.models.auth_schemes import UserInDB
+
+
+def get_user_by_username(username: str):
+    query_tuple = ("SELECT * FROM users WHERE username = %s", (username,))
+    result = db.execute_one(query_tuple)
+    if result["result"]:
+        return UserInDB(**result["result"][0])
+    else:
+        return None

--- a/bytepit_api/dependencies/auth_dependencies.py
+++ b/bytepit_api/dependencies/auth_dependencies.py
@@ -10,7 +10,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 
 from bytepit_api.helpers.login_helpers import get_user_by_email_or_username
-from bytepit_api.models.auth_schemes import TokenData, User 
+from bytepit_api.models.auth_schemes import TokenData, User
 
 
 class OAuth2PasswordBearerWithCookie(OAuth2):

--- a/bytepit_api/dependencies/auth_dependencies.py
+++ b/bytepit_api/dependencies/auth_dependencies.py
@@ -1,0 +1,75 @@
+import os
+
+from typing import Annotated, Dict, Optional
+
+from fastapi import Depends, HTTPException, status, Request
+from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
+from fastapi.security import OAuth2
+from fastapi.security.utils import get_authorization_scheme_param
+
+from jose import JWTError, jwt
+
+from bytepit_api.helpers.login_helpers import get_user_by_email_or_username
+from bytepit_api.models.auth_schemes import TokenData, User 
+
+
+class OAuth2PasswordBearerWithCookie(OAuth2):
+    def __init__(
+        self,
+        tokenUrl: str,
+        scheme_name: Optional[str] = None,
+        scopes: Optional[Dict[str, str]] = None,
+        auto_error: bool = True,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlowsModel(password={"tokenUrl": tokenUrl, "scopes": scopes})
+        super().__init__(flows=flows, scheme_name=scheme_name, auto_error=auto_error)
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization: str = request.cookies.get("access_token")
+        print("access_token is", authorization)
+
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            else:
+                return None
+        return param
+
+
+oauth2_scheme = OAuth2PasswordBearerWithCookie(tokenUrl="/auth/login")
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALGORITHM = "HS256"
+
+
+def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+        token_data = TokenData(email=email)
+    except JWTError:
+        raise credentials_exception
+    user = get_user_by_email_or_username(identifier=token_data.email)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def get_current_verified_user(current_user: Annotated[User, Depends(get_current_user)]):
+    if not current_user.is_verified:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user

--- a/bytepit_api/helpers/login_helpers.py
+++ b/bytepit_api/helpers/login_helpers.py
@@ -1,0 +1,39 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+from typing import Union
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from bytepit_api.database.queries import get_user_by_username
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALGORITHM = "HS256"
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password, password_hash):
+    return pwd_context.verify(plain_password, password_hash)
+
+
+def authenticate_user(username: str, password: str):
+    user = get_user_by_username(username)
+    if not user:
+        return False
+    if not verify_password(password, user.password_hash):
+        return False
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/bytepit_api/helpers/login_helpers.py
+++ b/bytepit_api/helpers/login_helpers.py
@@ -1,12 +1,12 @@
 import os
-from datetime import datetime, timedelta, timezone
 
+from datetime import datetime, timedelta, timezone
 from typing import Union
 
-from jose import JWTError, jwt
+from jose import jwt
 from passlib.context import CryptContext
 
-from bytepit_api.database.queries import get_user_by_username
+from bytepit_api.database.queries import get_user_by_email, get_user_by_username
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 ALGORITHM = "HS256"
@@ -19,8 +19,12 @@ def verify_password(plain_password, password_hash):
     return pwd_context.verify(plain_password, password_hash)
 
 
-def authenticate_user(username: str, password: str):
-    user = get_user_by_username(username)
+def check_if_email(identifier: str) -> bool:
+    return "@" in identifier
+
+
+def authenticate_user(identifier: str, password: str):
+    user = get_user_by_email_or_username(identifier)
     if not user:
         return False
     if not verify_password(password, user.password_hash):
@@ -37,3 +41,9 @@ def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+
+def get_user_by_email_or_username(identifier: str):
+    is_email = check_if_email(identifier)
+    user = get_user_by_email(identifier) if is_email else get_user_by_username(identifier)
+    return user

--- a/bytepit_api/models/auth_schemes.py
+++ b/bytepit_api/models/auth_schemes.py
@@ -34,6 +34,10 @@ class Token(BaseModel):
     token_type: str
 
 
+class TokenData(BaseModel):
+    email: Union[str, None] = None
+
+
 @as_form
 class RegistrationForm(BaseModel):
     username: Annotated[str, Form()]

--- a/bytepit_api/models/auth_schemes.py
+++ b/bytepit_api/models/auth_schemes.py
@@ -1,4 +1,5 @@
 import inspect
+import uuid
 
 from enum import Enum
 from typing import Annotated, Union
@@ -52,3 +53,17 @@ class LoginForm(BaseModel):
     client_id: Annotated[Union[str, None], Form()] = None
     client_secret: Annotated[Union[str, None], Form()] = None
     grant_type: Annotated[Union[str, None], Form(pattern="password")] = None
+
+
+class User(BaseModel):
+    username: str
+    email: str
+    role: str
+    name: str
+    surname: str
+    is_verified: bool
+
+
+class UserInDB(User):
+    id: uuid.UUID
+    password_hash: str

--- a/bytepit_api/routers/auth.py
+++ b/bytepit_api/routers/auth.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from bytepit_api.models.auth_schemes import LoginForm, RegistrationForm, Token
+from fastapi import APIRouter, Depends, HTTPException, status, Response
 
 from bytepit_api.helpers.login_helpers import authenticate_user, create_access_token
+from bytepit_api.models.auth_schemes import LoginForm, RegistrationForm, Token
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -23,12 +23,12 @@ def confirm_email(verification_token: str):
 
 
 @router.post("/login", response_model=Token)
-def login_for_access_token(form_data: Annotated[LoginForm, Depends()]):
+def login_for_access_token(response: Response, form_data: Annotated[LoginForm, Depends()]):
     user = authenticate_user(form_data.username, form_data.password)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password. If you have not verified your account, please do so before logging in.",
+            detail="Incorrect identifier (email/username) or password. If you have not verified your account, please do so before logging in.",
             headers={"WWW-Authenticate": "Bearer"},
         )
     if not user.is_verified:
@@ -38,7 +38,6 @@ def login_for_access_token(form_data: Annotated[LoginForm, Depends()]):
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
-    )
+    access_token = create_access_token(data={"sub": user.email}, expires_delta=access_token_expires)
+    response.set_cookie(key="access_token", value=f"Bearer {access_token}", httponly=True)
     return {"access_token": access_token, "token_type": "bearer"}

--- a/bytepit_api/routers/user.py
+++ b/bytepit_api/routers/user.py
@@ -1,0 +1,14 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from bytepit_api.dependencies.auth_dependencies import get_current_verified_user
+from bytepit_api.models.auth_schemes import User
+
+
+router = APIRouter(prefix="/user", tags=["user"])
+
+
+@router.get("/current", response_model=User)
+def get_current_users(current_user: Annotated[User, Depends(get_current_verified_user)]):
+    return current_user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 fastapi
+fastapi-mail
 pydantic[email]
 uvicorn
 requests
 python-multipart
 psycopg
+python-jose
+passlib[bcrypt]


### PR DESCRIPTION
COPIED FROM #6 (changes from that PR are included in this PR):

I also changed up ddl.sql a bit so it makes more sense, plus I added `created_on` column to `users` and `problems` tables. It's always good to have these.

At the moment, because we do not have `/register` endpoint, the only way to login is to manually insert a user row into users table and test it out that way:
1. (if not already done) Open database container in docker and run all the queries from our `ddl.sql` file to create tables, enum, index, extension...
2. Manually import user into database (run query in database docker container):
```
"INSERT INTO users (role, username, password_hash, email, name, surname, is_verified) 
VALUES ('Contestant', 'testcontestant', '$2b$12$KPLHOyQDeGr.vD.tilyUD.W7tHzZgimuNLJvT.V1xD6ulr5gRiMDy', 'test.contestant@example.com', 'TestName', 'TestSurname', true);"
```
3. Go to our swagger (http://localhost:8000/docs#) and test out the /auth/login endpoint by putting `testcontestant` as a username and `1234` as a password.
4. If you got access_token and a token_type as a response, it's working!